### PR TITLE
[KeepLatestNVersionImagesByProperty] Sort docker images by date before by version

### DIFF
--- a/artifactory_cleanup/rules/docker.py
+++ b/artifactory_cleanup/rules/docker.py
@@ -236,6 +236,7 @@ class KeepLatestNVersionImagesByProperty(RuleForDocker):
 
         for main_version, artifacts_ in grouped.items():
             artifacts_ = list(artifacts_)
+            artifacts_.sort(key=lambda x: x['created'], reverse=True)
             artifacts_.sort(key=self.get_version, reverse=True)
             # Keep latest N artifacts
             artifacts.keep(artifacts_[: self.count])


### PR DESCRIPTION
In my case, docker images version have this format: X.X.X-[commit id]

The regexp for capturing the version is `(^\d+\.\d+\.\d+)`

This regexp causes that many images have the same version string.

In this case only the X oldest versions are kepts.

So, the images should be sorted by creation date before being sorted by version.